### PR TITLE
Add more flexible naming for routes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,4 @@
+# 0.2.0.0 -- 2017.09.08
+* Add `YesodMetricsConfig` to allow control over certain features of the route 
+  names.
+* Alter various functions to require `YesodMetricsConfig`.

--- a/changelog.md
+++ b/changelog.md
@@ -10,3 +10,6 @@
 
 * Add `registerYesodMetricsMkMetricsFunction` to simplify initialization and 
   make sure `registerYesodMetrics`and `metrics` use the same data.
+
+* Create app in tests to make sure route names and store work as expected with 
+  different options.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,12 @@
 # 0.2.0.0 -- 2017.09.08
+
 * Add `YesodMetricsConfig` to allow control over certain features of the route 
   names.
+
+* Add `defaultYesodMetricsConfig`, `spacedYesodMetricsConfig`, 
+  `addSpacesToRoute` functions.
+
 * Alter various functions to require `YesodMetricsConfig`.
+
+* Add `registerYesodMetricsMkMetricsFunction` to simplify initialization and 
+  make sure `registerYesodMetrics`and `metrics` use the same data.

--- a/examples/yesod-with-metrics/app/Main.hs
+++ b/examples/yesod-with-metrics/app/Main.hs
@@ -56,5 +56,5 @@ main = do
     loop store = do
       sample <- sampleAll store
       print sample      
-      threadDelay 1000000
+      threadDelay 5000000
       loop store

--- a/examples/yesod-with-metrics/app/Main.hs
+++ b/examples/yesod-with-metrics/app/Main.hs
@@ -41,7 +41,7 @@ main :: IO ()
 main = do
   app <- toWaiApp App
   store <- newStore
-  yesodMetrics <- Yesod.registerYesodMetrics True "routes" routesFileContents store
+  yesodMetricsF <- Yesod.registerYesodMetricsMkMetricsFunction Yesod.spacedYesodMetricsConfig routesFileContents store
   registerGcMetrics store
   
   -- print store contents
@@ -49,7 +49,7 @@ main = do
   
   _ <- forkServerWith store "localhost" 7000
   
-  run 3000 (Yesod.metrics routesFileContents yesodMetrics $ app)
+  run 3000 (yesodMetricsF $ app)
   
   where
     -- see store updates on the server side

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: yesod-routes-metrics
-version: '0.1.0.0'
+version: '0.2.0.0'
 synopsis: Parser Yesod routes file and compute route access metrics for Yesod
 description: README.md
 category: Web
@@ -37,6 +37,8 @@ tests:
     main: Spec.hs
     dependencies:
     - base >= 4.7 && < 5
+    - containers
+    - ekg-core
     - hspec
     - http-types
     - network

--- a/package.yaml
+++ b/package.yaml
@@ -37,13 +37,20 @@ tests:
     main: Spec.hs
     dependencies:
     - base >= 4.7 && < 5
+    - bytestring
     - containers
+    - ekg
     - ekg-core
+    - file-embed
     - hspec
     - http-types
+    - HTTP
     - network
+    - text
+    - unordered-containers
     - vault
+    - yesod
     - yesod-core
     - yesod-routes-metrics
     - wai
-    
+    - warp

--- a/src/Yesod/Routes/Metrics.hs
+++ b/src/Yesod/Routes/Metrics.hs
@@ -4,7 +4,9 @@ module Yesod.Routes.Metrics (
    YesodMetrics(..)
  , YesodMetricsConfig(..)
  , defaultYesodMetricsConfig
+ , spacedYesodMetricsConfig
  , addSpacesToRoute
+ , registerYesodMetricsMkMetricsFunction
  , registerYesodMetrics
  , registerYesodMetricsWithResourceTrees
  , metrics
@@ -43,8 +45,18 @@ data YesodMetricsConfig =
 defaultYesodMetricsConfig :: YesodMetricsConfig
 defaultYesodMetricsConfig = YesodMetricsConfig "" True True id
 
+spacedYesodMetricsConfig :: YesodMetricsConfig
+spacedYesodMetricsConfig = YesodMetricsConfig "" True False addSpacesToRoute
+
+-- | Make route names more readable by adding spaces.
 addSpacesToRoute :: String -> String
 addSpacesToRoute = concat . fmap (\x -> if isUpper x then (" " ++ [x]) else [x])
+
+
+registerYesodMetricsMkMetricsFunction :: YesodMetricsConfig -> ByteString -> Store -> IO Middleware
+registerYesodMetricsMkMetricsFunction config routesFileContents store = do
+  ym <- registerYesodMetrics config routesFileContents store
+  return $ metrics config routesFileContents ym
 
 registerYesodMetrics :: YesodMetricsConfig -> ByteString -> Store -> IO YesodMetrics
 registerYesodMetrics config routesFileContents store = do

--- a/src/Yesod/Routes/Metrics.hs
+++ b/src/Yesod/Routes/Metrics.hs
@@ -111,7 +111,7 @@ metricsWithResourceTrees ymc resources yesodMetrics app req respond = do
   -- then update its corresponding counter
   case mRouteName of
     Nothing        -> return ()
-    Just routeName -> updateRoute routeName
+    Just routeName -> updateRoute $ (alterRouteName ymc) routeName
           
   app req $ respond'
 

--- a/src/Yesod/Routes/Metrics.hs
+++ b/src/Yesod/Routes/Metrics.hs
@@ -6,6 +6,7 @@ module Yesod.Routes.Metrics (
  , defaultYesodMetricsConfig
  , spacedYesodMetricsConfig
  , addSpacesToRoute
+ , removeUnderlines
  , registerYesodMetricsMkMetricsFunction
  , registerYesodMetrics
  , registerYesodMetricsWithResourceTrees
@@ -52,6 +53,14 @@ spacedYesodMetricsConfig = YesodMetricsConfig "" True False addSpacesToRoute
 addSpacesToRoute :: String -> String
 addSpacesToRoute = concat . fmap (\x -> if isUpper x then (" " ++ [x]) else [x])
 
+removeUnderlines :: String -> String
+removeUnderlines = 
+  fmap (\c -> 
+    case c of 
+      '_' -> ' '
+      _   -> c
+    )
+
 
 registerYesodMetricsMkMetricsFunction :: YesodMetricsConfig -> ByteString -> Store -> IO Middleware
 registerYesodMetricsMkMetricsFunction config routesFileContents store = do
@@ -86,11 +95,7 @@ registerYesodMetricsWithResourceTrees ymc resources store = do
     alterResponseStatus =
       if underlined ymc
         then id
-        else fmap (\c -> 
-                    case c of 
-                      '_' -> ' '
-                      _   -> c
-                  )
+        else removeUnderlines
                       
     responseStatuses' = T.pack . alterResponseStatus <$> responseStatuses
     
@@ -134,11 +139,7 @@ metricsWithResourceTrees ymc resources yesodMetrics app req respond = do
             alterResponseStatus =
               if underlined ymc
                 then id
-                else fmap (\c -> 
-                            case c of 
-                              '_' -> ' '
-                              _   -> c
-                          )
+                else removeUnderlines
       respond res
     
     updateRoute name = 

--- a/src/Yesod/Routes/Util.hs
+++ b/src/Yesod/Routes/Util.hs
@@ -1,5 +1,6 @@
 module Yesod.Routes.Util where
-  
+
+import           Data.Char (isUpper)  
 import           Yesod.Routes.TH.Types
 
 -- useful for testing and debugging
@@ -11,3 +12,6 @@ showResourceTree (ResourceParent s co ps rts) =
   where 
     showPiece p = 
       ", " ++ show p
+
+prettyPrintRouteName :: String -> String
+prettyPrintRouteName =  concat . fmap (\c -> if isUpper c then (" " ++ [c]) else [c])

--- a/test/App.hs
+++ b/test/App.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+module App (runYesodServer) where
+
+import           Control.Concurrent (forkIO, threadDelay)
+import           Data.ByteString.Char8 (unpack)
+import           Data.ByteString (ByteString)
+import           Data.FileEmbed
+import           Data.Monoid ((<>))
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Foundation
+import           Network.Wai.Handler.Warp (run)
+import           System.Metrics           (newStore, registerGcMetrics, sampleAll, Store)
+import           Yesod
+import qualified Yesod.Routes.Metrics as Yesod
+import           System.Remote.Monitoring (forkServerWith)
+
+mkYesodDispatch "App" resourcesApp
+
+routesFileContents :: ByteString
+routesFileContents = $(embedFile "test/config/routes")
+
+getHomeR :: Handler Text
+getHomeR = return "Hello World!"
+
+postNewUserR :: Handler Text
+postNewUserR = return $ "Making a new user"
+
+getUserR :: Int -> Handler Text
+getUserR userId = return $ "User with id: " <> (T.pack . show $ userId)
+
+deleteUserR :: Int -> Handler Text
+deleteUserR userId = return $ "Deleted user with id: " <> (T.pack . show $ userId)
+
+runYesodServer :: Int -> Yesod.YesodMetricsConfig -> Store -> IO ()
+runYesodServer port ymc store = do
+  app <- toWaiApp App
+  yesodMetricsF <- Yesod.registerYesodMetricsMkMetricsFunction ymc routesFileContents store
+  registerGcMetrics store  
+  run port (yesodMetricsF $ app)

--- a/test/Foundation.hs
+++ b/test/Foundation.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+module Foundation where
+
+import           Data.Text (Text)
+import           Yesod
+  
+data App = App
+instance Yesod App
+
+mkYesodData "App" $(parseRoutesFile "test/config/routes")

--- a/test/config/routes
+++ b/test/config/routes
@@ -1,0 +1,5 @@
+/ HomeR GET
+
+/user      NewUserR POST 
+
+/user/#Int UserR    GET DELETE


### PR DESCRIPTION
Originally it would only provide keys for routes like this:

```
getHomeR
getHomeR_response_status_1xx
getHomeR_response_status_2xx
getHomeR_response_status_3xx
getHomeR_response_status_4xx
getHomeR_response_status_5xx
```

Now it can optionally produce things like


```
getHomeR
getHomeR response status 1xx
getHomeR response status 2xx
getHomeR response status 3xx
getHomeR response status 4xx
getHomeR response status 5xx
```

or

```
get Home R
get Home R response status 1xx
get Home R response status 2xx
get Home R response status 3xx
get Home R response status 4xx
get Home R response status 5xx
```